### PR TITLE
Added a POST only , non-ajax, flow for strict browsers

### DIFF
--- a/adduser.html
+++ b/adduser.html
@@ -6,7 +6,7 @@
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
   <!-- jquery -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <script src="https://s.brightspace.com/lib/jquery/3.7.1/jquery.min.js"></script>
   <!-- Brightspace button style -->
   <style>
         .btn-primary {
@@ -26,7 +26,8 @@
 </head>
 <body style="font-family: 'Lato', sans-serif;color: #202122;">
 <div class="container">
-  <form method="post" id="quickAddForm">
+  <form method="post" id="quickAddForm" action="adduser.php">
+    <input type="hidden" name="session_id" value="%s"> 
     <div class="mb-3">
       <label class="form-label" id="output"></label>
       <input type="text" class="form-control" id="username" required placeholder="Enter username" name="username">

--- a/adduser.html
+++ b/adduser.html
@@ -63,7 +63,7 @@
 
   if (isSafari) {
     // Use conventional form submission for Safari
-    document.getElementById("quickAddForm").submit();
+    console.log("Safari detected. Using conventional form submission.");
   } else {
 
     $(document).ready(function() {

--- a/adduser.html
+++ b/adduser.html
@@ -57,50 +57,60 @@
 <div>
   <script type="text/javascript">
   let feedbackdiv = document.getElementById("quickAddResponse");
-  $(document).ready(function() {
-    $('#quickAddForm').submit(function(e) {
-        e.preventDefault();
-        $.ajax({
-            type: "POST",
-            url: 'adduser.php',
-            data: $(this).serialize(),
-            dataType: "json",
-            success: function(response)
-            {
-               if (response == "Success"){
-                  feedbackdiv.className = 'alert alert-success';
-                  feedbackdiv.innerHTML = "User successfully added to all course Sections";
-                  feedbackdiv.focus();
-                  document.getElementById("quickAddForm").reset();
-                  setTimeout(function(){feedbackdiv.removeAttribute('class');
-                                        feedbackdiv.innerHTML = "";},
-                            5000);
-               }
-               else {
-                  feedbackdiv.className = 'alert alert-danger';
-                  feedbackdiv.innerHTML = response;
-                  feedbackdiv.focus();
-                  setTimeout(function(){feedbackdiv.removeAttribute('class');
-                                        feedbackdiv.innerHTML = "";
-                                        document.getElementById("quickAddForm").reset();},
-                            5000);
 
-               }
-            }
+  // Check if the browser is Safari
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+  if (isSafari) {
+    // Use conventional form submission for Safari
+    document.getElementById("quickAddForm").submit();
+  } else {
+
+    $(document).ready(function() {
+      $('#quickAddForm').submit(function(e) {
+          e.preventDefault();
+          $.ajax({
+              type: "POST",
+              url: 'adduser.php',
+              data: $(this).serialize(),
+              dataType: "json",
+              success: function(response)
+              {
+                if (response == "Success"){
+                    feedbackdiv.className = 'alert alert-success';
+                    feedbackdiv.innerHTML = "User successfully added to all course Sections";
+                    feedbackdiv.focus();
+                    document.getElementById("quickAddForm").reset();
+                    setTimeout(function(){feedbackdiv.removeAttribute('class');
+                                          feedbackdiv.innerHTML = "";},
+                              5000);
+                }
+                else {
+                    feedbackdiv.className = 'alert alert-danger';
+                    feedbackdiv.innerHTML = response;
+                    feedbackdiv.focus();
+                    setTimeout(function(){feedbackdiv.removeAttribute('class');
+                                          feedbackdiv.innerHTML = "";
+                                          document.getElementById("quickAddForm").reset();},
+                              5000);
+
+                }
+              }
+          });
         });
-      });
-  });
-  $(document)
-  .ajaxStart(function () {
-    feedbackdiv.innerHTML = "";
-    feedbackdiv.className = "";
-    document.getElementById("quickAddSpinner").className = "spinner-border";
-    document.getElementById("quickAddSpinner").innerHTML = '<span class="visually-hidden">Loading...</span>';
-  })
-  .ajaxStop(function () {
-    document.getElementById("quickAddSpinner").className = "";
-    document.getElementById("quickAddSpinner").innerHTML = "";
-  });
+    });
+    $(document)
+    .ajaxStart(function () {
+      feedbackdiv.innerHTML = "";
+      feedbackdiv.className = "";
+      document.getElementById("quickAddSpinner").className = "spinner-border";
+      document.getElementById("quickAddSpinner").innerHTML = '<span class="visually-hidden">Loading...</span>';
+    })
+    .ajaxStop(function () {
+      document.getElementById("quickAddSpinner").className = "";
+      document.getElementById("quickAddSpinner").innerHTML = "";
+    });
+  }
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
 </body>

--- a/adduser.php
+++ b/adduser.php
@@ -4,6 +4,10 @@ require_once 'lib/D2LAppContextFactory.php';
 
 //read LTI tool Key and OrgUnitID passed by session from main page index.php
 
+//Detects if session_id is empty, then looks to see if one has been stashed in a hidden form item to allow cross domain requests
+$a = session_id();
+if(empty($a) && !empty($_POST["session_id"])) session_id($_POST["session_id"]); 
+
 session_start();
 $toolKey = $_SESSION['toolKey'];
 $orgUnitId =$_SESSION['OrgUnitId'];

--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@ session_write_close();
 //Check the key is correct
 if($lti_auth['key'] == $context->info['oauth_consumer_key']){
         //bring quickAdd HTML page
-        readfile("adduser.html");
+        echo sprintf(file_get_contents("adduser.html"),session_id()); //Adds session_id() to a hidden form element to allow cross domain requests
 }
 else{
         echo 'LTI credentials not valid. Please refresh the page and try again. If you continue to receive this message please contact <a href="mailto:'.$supportEmail.'?Subject=Quick Add Widget Issue" target="_top">'.$supportEmail.'</a>';


### PR DESCRIPTION
adduser.html now has a hidden form element with the PHPSESSIONID in it and an action on form for adduser.php.
Javascript changes detect Safari and don't use ajax when Safari is in use, reverting to conventional POST

adduser.php detects if it has a session id and if it doesn't looks to resume it via the one POST'ed.

index.php was modified to place the PHPSESSIONID in the form.